### PR TITLE
Clarify ProSheets 2.4.0 Forma export documentation

### DIFF
--- a/docs/ui-components/Create-tab.md
+++ b/docs/ui-components/Create-tab.md
@@ -35,7 +35,7 @@ Select the "Local" checkbox and open the "Local" tab. Use the "Folder Selection"
 
 ### Forma
 
-ProSheets can automatically upload generated export files to Autodesk Forma Document Management. Select the option "Forma" and choose a Hub, Project, and folder from your Forma account as the export location.
+ProSheets can export files to Autodesk Forma Document Management. Select the option "Forma" and choose a Hub, Project, and folder from your Forma account as the export location.
 
 #### Install and authorize the DiRoots Connector
 
@@ -45,12 +45,9 @@ Steps for Hub Administrators:
 
 1. Sign in to Autodesk Forma and open "Hub Admin" for the required Hub.
 2. Open "Apps".
-3. Select the "Featured Apps" tab.
-4. Select "DiRoots Connector".
-5. Click "Add to Build".
-6. Click "Authorize".
-
-For more information, see Autodesk's [App Gallery documentation](https://help.autodesk.com/cloudhelp/ENG/Docs-Admin/files/hub-administration/ACCOUNT_ADMINISTRATION_APP_Gallery.html).
+3. Select "DiRoots Connector for Autodesk Forma" from the App Gallery.
+4. Click "Install".
+5. Review the requested permissions, then click "Authorize and Install".
 
 Install the connector separately for each Hub where ProSheets will be used. ProSheets users can then follow the steps below to log in to Forma.
 
@@ -86,7 +83,7 @@ The Forma Explorer allows you to expand and collapse folders and displays inform
 
 After selecting a folder, the Forma path will be displayed in the Create tab.
 
-After ProSheets generates each export, it uploads the file to the selected Forma folder. If a file with the same name already exists, the upload creates a new version of the existing file instead of creating a duplicate.
+After ProSheets generates each export, it uploads the file to the selected Forma folder. If a file with the same name already exists, the upload creates a new version of the existing file.
 
 ![ProSheets export files to Autodesk Forma](../../assets/images/GIFs/Export/PS-Forma-Export.gif)  
 <sub>Note: the version on the image may not reflect the [latest version of ProSheets](https://diroots.com/revit-plugins/revit-to-pdf-dwg-dgn-dwf-nwc-ifc-and-images-with-prosheets/).</sub>
@@ -102,7 +99,7 @@ Use the radio buttons to choose how ProSheets organizes the exported files.
 
 ### Environment variables
 
-ProSheets allows you to use environment variables in the Local "Folder Selection" path.
+You can use environment variables to build the saving path.
 
 #### Supported environment variables:
 
@@ -171,7 +168,7 @@ Use the format filter to display rows for one file format. The dropdown includes
 
 You can combine the search, Views/Sheets, and format filters.
 
-> **Important:** Filters only change which rows are displayed. Hidden items remain in the export queue and will still be exported. To prevent an item from being exported, remove it from the queue.
+> **Important:** Filters only change which rows are displayed. Hidden items remain in the export queue and will still be exported. To stop an item from being exported, remove it from the queue.
 
 ![ProSheets filter views, sheets, and file formats](../../assets/images/GIFs/Export/PS-Create-Tab-Filters.gif)  
 <sub>Note: the version on the image may not reflect the [latest version of ProSheets](https://diroots.com/revit-plugins/revit-to-pdf-dwg-dgn-dwf-nwc-ifc-and-images-with-prosheets/).</sub>

--- a/docs/ui-components/Create-tab.md
+++ b/docs/ui-components/Create-tab.md
@@ -25,7 +25,7 @@ nav_order: 3
 
 ProSheets allows you to export files locally, to Autodesk Forma, or to both destinations in the same export job.
 
-Use the checkboxes under "Export Rules" to select "Local", "Forma", or both. Select the corresponding tab to configure each export location.
+Use the checkboxes under "Export Rules" to select "Local", "Forma", or both. Select the corresponding tab to configure each export location. When both options are selected, ProSheets saves the generated files to the configured local folder and uploads them to the selected Forma folder in the same export job.
 
 ### Local
 
@@ -35,7 +35,7 @@ Select the "Local" checkbox and open the "Local" tab. Use the "Folder Selection"
 
 ### Forma
 
-ProSheets allows you to export files directly to Autodesk Forma Document Management. Select the option "Forma" and choose a Hub, Project, and folder from your Forma account as the export location.
+ProSheets can automatically upload generated export files to Autodesk Forma Document Management. Select the option "Forma" and choose a Hub, Project, and folder from your Forma account as the export location.
 
 #### Install and authorize the DiRoots Connector
 
@@ -45,9 +45,12 @@ Steps for Hub Administrators:
 
 1. Sign in to Autodesk Forma and open "Hub Admin" for the required Hub.
 2. Open "Apps".
-3. Select "DiRoots Connector for Autodesk Forma" from the App Gallery.
-4. Click "Install".
-5. Review the requested permissions, then click "Authorize and Install".
+3. Select the "Featured Apps" tab.
+4. Select "DiRoots Connector".
+5. Click "Add to Build".
+6. Click "Authorize".
+
+For more information, see Autodesk's [App Gallery documentation](https://help.autodesk.com/cloudhelp/ENG/Docs-Admin/files/hub-administration/ACCOUNT_ADMINISTRATION_APP_Gallery.html).
 
 Install the connector separately for each Hub where ProSheets will be used. ProSheets users can then follow the steps below to log in to Forma.
 
@@ -83,7 +86,7 @@ The Forma Explorer allows you to expand and collapse folders and displays inform
 
 After selecting a folder, the Forma path will be displayed in the Create tab.
 
-When the export starts, ProSheets creates a new file in the selected folder. If a file with the same name already exists, ProSheets uploads the exported file as a new version of the existing file.
+After ProSheets generates each export, it uploads the file to the selected Forma folder. If a file with the same name already exists, the upload creates a new version of the existing file instead of creating a duplicate.
 
 ![ProSheets export files to Autodesk Forma](../../assets/images/GIFs/Export/PS-Forma-Export.gif)  
 <sub>Note: the version on the image may not reflect the [latest version of ProSheets](https://diroots.com/revit-plugins/revit-to-pdf-dwg-dgn-dwf-nwc-ifc-and-images-with-prosheets/).</sub>
@@ -99,7 +102,7 @@ Use the radio buttons to choose how ProSheets organizes the exported files.
 
 ### Environment variables
 
-ProSheets allows you to use environment variables in the "Folder Selection" path for Local and Forma exports.
+ProSheets allows you to use environment variables in the Local "Folder Selection" path.
 
 #### Supported environment variables:
 
@@ -166,7 +169,9 @@ Use the Views/Sheets (V/S) filter in the column header to display rows by item t
 
 Use the format filter to display rows for one file format. The dropdown includes only the formats selected in the Format tab. Select "All Formats" to clear the format filter.
 
-You can combine the search, Views/Sheets, and format filters. Items hidden by the search or filters remain in the export queue and are still exported.
+You can combine the search, Views/Sheets, and format filters.
+
+> **Important:** Filters only change which rows are displayed. Hidden items remain in the export queue and will still be exported. To prevent an item from being exported, remove it from the queue.
 
 ![ProSheets filter views, sheets, and file formats](../../assets/images/GIFs/Export/PS-Create-Tab-Filters.gif)  
 <sub>Note: the version on the image may not reflect the [latest version of ProSheets](https://diroots.com/revit-plugins/revit-to-pdf-dwg-dgn-dwf-nwc-ifc-and-images-with-prosheets/).</sub>


### PR DESCRIPTION
## What changed

- Aligns the DiRoots Connector authorization steps with Autodesk's current Hub Admin App Gallery workflow.
- Clarifies that ProSheets generates exports before uploading them to Forma.
- Explains that same-name uploads create a new file version instead of a duplicate.
- Explains what happens when Local and Forma are both selected.
- Makes it more obvious that filtering rows does not exclude them from the export.

## Why

The documentation introduced in #14 could send hub administrators to controls that do not exist under Autodesk's current terminology and could confuse users about upload timing, version behavior, Forma paths, and filtering.

## User impact

Administrators get an actionable connector setup procedure, while ProSheets users get a clearer explanation of the 2.4.0 export and queue behavior.

## Validation

- Branched from #14 head commit `a6edc5943496d6b3667a996d3718f378a009cb78`.
- The branch is one commit ahead and modifies only `docs/ui-components/Create-tab.md`.
- Connector steps were checked against Autodesk's current App Gallery documentation:
  https://help.autodesk.com/cloudhelp/ENG/Docs-Admin/files/hub-administration/ACCOUNT_ADMINISTRATION_APP_Gallery.html